### PR TITLE
feat: 評価値表示機能の実装 (#2)

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -6,13 +6,21 @@ import GameBoard from './GameBoard';
 import GameInfo from './GameInfo';
 import { GameErrorBoundary } from './GameErrorBoundary';
 import { Board } from '@/types/game';
-import { useGameState, useGameSettings, useAIPlayer } from '@/hooks';
+import { useGameState, useGameSettings, useAIPlayer, useMoveEvaluation } from '@/hooks';
 import { isValidMove, makeMove, getOpponent } from '@/lib/gameLogic';
 
 export default function Game() {
   const { gameState, lastMove, setLastMove, updateGameState, resetGame } = useGameState();
-  const { showHints, isVsComputer, difficulty, toggleHints, toggleGameMode, setDifficulty } =
-    useGameSettings();
+  const {
+    showHints,
+    showEvaluations,
+    isVsComputer,
+    difficulty,
+    toggleHints,
+    toggleEvaluations,
+    toggleGameMode,
+    setDifficulty,
+  } = useGameSettings();
 
   const handleAIMove = useCallback(
     (board: Board, nextPlayer: 'black' | 'white', move: { row: number; col: number }) => {
@@ -28,6 +36,13 @@ export default function Game() {
     difficulty,
     onMove: handleAIMove,
   });
+
+  const moveEvaluations = useMoveEvaluation(
+    gameState.board,
+    gameState.currentPlayer,
+    gameState.possibleMoves,
+    difficulty
+  );
 
   const handleCellClick = useCallback(
     (row: number, col: number) => {
@@ -87,6 +102,8 @@ export default function Game() {
                 possibleMoves={gameState.possibleMoves}
                 onCellClick={handleCellClick}
                 showHints={showHints}
+                showEvaluations={showEvaluations}
+                moveEvaluations={moveEvaluations}
                 lastMove={lastMove}
               />
             </div>
@@ -99,7 +116,9 @@ export default function Game() {
               winner={gameState.winner}
               onNewGame={resetGame}
               onToggleHints={toggleHints}
+              onToggleEvaluations={toggleEvaluations}
               showHints={showHints}
+              showEvaluations={showEvaluations}
               isVsComputer={isVsComputer}
               difficulty={difficulty}
               onToggleGameMode={toggleGameMode}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -9,6 +9,8 @@ interface GameBoardProps {
   possibleMoves?: Position[];
   onCellClick: (row: number, col: number) => void;
   showHints: boolean;
+  showEvaluations?: boolean;
+  moveEvaluations?: Map<string, { normalizedScore: number }>;
   lastMove?: Position | null;
   highlightPositions?: [number, number][];
 }
@@ -19,6 +21,8 @@ function GameBoard({
   possibleMoves = [],
   onCellClick,
   showHints,
+  showEvaluations = false,
+  moveEvaluations,
   lastMove,
   highlightPositions = [],
 }: GameBoardProps) {
@@ -32,6 +36,19 @@ function GameBoard({
 
   const isHighlighted = (row: number, col: number) => {
     return highlightPositions.some((pos) => pos[0] === row && pos[1] === col);
+  };
+
+  const getEvaluationScore = (row: number, col: number) => {
+    if (!moveEvaluations) return null;
+    const key = `${row}-${col}`;
+    return moveEvaluations.get(key)?.normalizedScore ?? null;
+  };
+
+  const getEvaluationColor = (score: number) => {
+    if (score >= 50) return 'text-green-600 font-bold';
+    if (score >= 0) return 'text-green-500';
+    if (score >= -50) return 'text-orange-500';
+    return 'text-red-500 font-bold';
   };
 
   return (
@@ -65,6 +82,18 @@ function GameBoard({
               {showHints && isPossibleMove(rowIndex, colIndex) && !cell && (
                 <div className="absolute w-3 h-3 bg-yellow-400/50 rounded-full animate-pulse" />
               )}
+              {showEvaluations && isPossibleMove(rowIndex, colIndex) && !cell && (() => {
+                const score = getEvaluationScore(rowIndex, colIndex);
+                return score !== null ? (
+                  <div
+                    className={`absolute text-xs md:text-sm font-semibold ${
+                      getEvaluationColor(score)
+                    }`}
+                  >
+                    {score > 0 ? '+' : ''}{score}
+                  </div>
+                ) : null;
+              })()}
             </div>
           ))
         )}

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -12,7 +12,9 @@ interface GameInfoProps {
   winner: Player;
   onNewGame: () => void;
   onToggleHints: () => void;
+  onToggleEvaluations: () => void;
   showHints: boolean;
+  showEvaluations: boolean;
   isVsComputer: boolean;
   difficulty: 'easy' | 'medium' | 'hard';
   onToggleGameMode: () => void;
@@ -28,7 +30,9 @@ function GameInfo({
   winner,
   onNewGame,
   onToggleHints,
+  onToggleEvaluations,
   showHints,
+  showEvaluations,
   isVsComputer,
   difficulty,
   onToggleGameMode,
@@ -116,6 +120,17 @@ function GameInfo({
           }`}
         >
           ヒント: {showHints ? 'ON' : 'OFF'}
+        </button>
+
+        <button
+          onClick={onToggleEvaluations}
+          className={`w-full py-2 px-4 rounded-lg transition-colors font-semibold ${
+            showEvaluations
+              ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+              : 'bg-gray-300 text-gray-700 hover:bg-gray-400'
+          }`}
+        >
+          評価値: {showEvaluations ? 'ON' : 'OFF'}
         </button>
 
         <div className="border-t pt-3">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useGameState } from './useGameState';
 export { useGameSettings, type Difficulty } from './useGameSettings';
 export { useAIPlayer } from './useAIPlayer';
 export { useLocalStorage } from './useLocalStorage';
+export { useMoveEvaluation } from './useMoveEvaluation';

--- a/src/hooks/useGameSettings.ts
+++ b/src/hooks/useGameSettings.ts
@@ -5,12 +5,14 @@ export type Difficulty = 'easy' | 'medium' | 'hard';
 
 interface GameSettings {
   showHints: boolean;
+  showEvaluations: boolean;
   isVsComputer: boolean;
   difficulty: Difficulty;
 }
 
 const DEFAULT_SETTINGS: GameSettings = {
   showHints: true,
+  showEvaluations: false,
   isVsComputer: true,
   difficulty: 'medium',
 };
@@ -23,6 +25,10 @@ export function useGameSettings() {
 
   const toggleHints = useCallback(() => {
     setSettings((prev) => ({ ...prev, showHints: !prev.showHints }));
+  }, [setSettings]);
+
+  const toggleEvaluations = useCallback(() => {
+    setSettings((prev) => ({ ...prev, showEvaluations: !prev.showEvaluations }));
   }, [setSettings]);
 
   const toggleGameMode = useCallback(() => {
@@ -38,9 +44,11 @@ export function useGameSettings() {
 
   return {
     showHints: settings.showHints,
+    showEvaluations: settings.showEvaluations,
     isVsComputer: settings.isVsComputer,
     difficulty: settings.difficulty,
     toggleHints,
+    toggleEvaluations,
     toggleGameMode,
     setDifficulty,
   };

--- a/src/hooks/useMoveEvaluation.ts
+++ b/src/hooks/useMoveEvaluation.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Board, Player, Position } from '@/types/game';
+import { evaluateMove } from '@/lib/ai';
+
+interface MoveEvaluation {
+  position: Position;
+  score: number;
+  normalizedScore: number; // -100 to 100
+}
+
+export function useMoveEvaluation(
+  board: Board,
+  player: Player | null,
+  possibleMoves: Position[],
+  difficulty: 'easy' | 'medium' | 'hard' = 'medium'
+): Map<string, MoveEvaluation> {
+  return useMemo(() => {
+    const evaluations = new Map<string, MoveEvaluation>();
+
+    if (!player || possibleMoves.length === 0) {
+      return evaluations;
+    }
+
+    // Calculate scores for all possible moves
+    const scores = possibleMoves.map((move) => ({
+      position: move,
+      score: evaluateMove(board, move, player, difficulty),
+    }));
+
+    // Find min and max scores for normalization
+    const minScore = Math.min(...scores.map((s) => s.score));
+    const maxScore = Math.max(...scores.map((s) => s.score));
+    const scoreRange = maxScore - minScore || 1; // Avoid division by zero
+
+    // Normalize scores to -100 to 100 range
+    scores.forEach(({ position, score }) => {
+      const normalizedScore = scoreRange === 0 
+        ? 0 
+        : Math.round(((score - minScore) / scoreRange) * 200 - 100);
+
+      const key = `${position.row}-${position.col}`;
+      evaluations.set(key, {
+        position,
+        score,
+        normalizedScore,
+      });
+    });
+
+    return evaluations;
+  }, [board, player, possibleMoves, difficulty]);
+}


### PR DESCRIPTION
## 概要
Issue #2 の実装として、各手の評価値を表示する機能を追加しました。

## 実装内容
- ✅ フックを作成し、可能な手すべての評価値を計算
- ✅ 評価値を-100〜+100の範囲に正規化し、色分けで表示
  - 緑色: 良い手（+50以上）
  - オレンジ色: 普通の手（-50〜0）
  - 赤色: 悪い手（-50未満）
- ✅ ゲーム設定に評価値表示のON/OFF切り替え機能を追加
- ✅ GameBoardコンポーネントに評価値オーバーレイを統合

## 動作確認
- 評価値表示をONにすると、配置可能なマスに評価値が表示されます
- 評価値は現在のAI難易度設定に基づいて計算されます
- ヒント表示と評価値表示は独立して切り替え可能です

## スクリーンショット
検証環境で動作確認をお願いします。

Closes #2