### PR TITLE
fix: improve white piece contrast on white background (#5)

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
       colors: {
         'board-green': '#00a86b',
         'piece-black': '#1a1a1a',
-        'piece-white': '#f0f0f0',
+        'piece-white': '#e0e0e0',
       },
       animation: {
         flip: 'flip 0.6s ease-in-out',


### PR DESCRIPTION
## Summary
白い背景に白い石が見えにくい問題を修正

## Changes
- `piece-white`の色を`#f0f0f0`から`#e0e0e0`に変更
- GameInfoコンポーネントの白い背景に対するコントラストを改善

## Test Plan
- [x] ESLintとテストの実行確認
- [x] 白い石の視認性確認

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)